### PR TITLE
add AsyncResult.bindError

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,10 +2,10 @@ name: Build and Test
 
 on:
   push:
-    branches: 
-     - '*'
+    branches:
+      - "*"
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore /WarnAsError
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/publish_to_NuGet.yml
+++ b/.github/workflows/publish_to_NuGet.yml
@@ -4,7 +4,6 @@ on:
   release:
     types: [created, edited]
 
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -23,5 +22,3 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
         run: dotnet nuget push Release/*.nupkg --skip-duplicate --no-symbols true --source https://api.nuget.org/v3/index.json -k ${NUGET_AUTH_TOKEN}
-     
-  

--- a/src/Insurello.AsyncExtra.Tests/Insurello.AsyncExtra.Tests.fsproj
+++ b/src/Insurello.AsyncExtra.Tests/Insurello.AsyncExtra.Tests.fsproj
@@ -8,12 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
     <Compile Include="AsyncExtraTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="8.*" />
+    <PackageReference Include="Expecto" Version="9.*" />
     <PackageReference Include="FSharp.Core" Version="4.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -44,10 +44,21 @@ module AsyncResult =
 
                 | Error err -> Async.singleton (Error err))
 
+    let bindError: ('errT -> AsyncResult<'x, 'errU>) -> AsyncResult<'x, 'errT> -> AsyncResult<'x, 'errU> =
+        fun f asyncResultErrT ->
+            asyncResultErrT
+            |> Async.bind (function
+                | Ok x -> Async.singleton (Ok x)
+
+                | Error err -> f err)
+
     let sequence: AsyncResult<'x, 'error> list -> AsyncResult<'x list, 'error> =
         let folder: AsyncResult<'x list, 'error> -> AsyncResult<'x, 'error> -> AsyncResult<'x list, 'error> =
             fun acc nextAsyncResult ->
-                acc |> bind (fun okValues -> nextAsyncResult |> map (fun nextOkValue -> nextOkValue :: okValues))
+                acc
+                |> bind (fun okValues ->
+                    nextAsyncResult
+                    |> map (fun nextOkValue -> nextOkValue :: okValues))
 
         fun asyncs ->
             asyncs

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -37,20 +37,16 @@ module AsyncResult =
         fun f asyncResultX -> Async.map (Result.mapError f) asyncResultX
 
     let bind: ('x -> AsyncResult<'y, 'err>) -> AsyncResult<'x, 'err> -> AsyncResult<'y, 'err> =
-        fun f asyncResultX ->
-            asyncResultX
-            |> Async.bind (function
-                | Ok x -> f x
-
+        fun successMapper ->
+            Async.bind (function
+                | Ok x -> successMapper x
                 | Error err -> Async.singleton (Error err))
 
     let bindError: ('errT -> AsyncResult<'x, 'errU>) -> AsyncResult<'x, 'errT> -> AsyncResult<'x, 'errU> =
-        fun f asyncResultErrT ->
-            asyncResultErrT
-            |> Async.bind (function
+        fun errorMapper ->
+            Async.bind (function
                 | Ok x -> Async.singleton (Ok x)
-
-                | Error err -> f err)
+                | Error err -> errorMapper err)
 
     let sequence: AsyncResult<'x, 'error> list -> AsyncResult<'x list, 'error> =
         let folder: AsyncResult<'x list, 'error> -> AsyncResult<'x, 'error> -> AsyncResult<'x list, 'error> =

--- a/src/Insurello.AsyncExtra/Insurello.AsyncExtra.fsproj
+++ b/src/Insurello.AsyncExtra/Insurello.AsyncExtra.fsproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <PropertyGroup>
     <OtherFlags>$(OtherFlags) --warnon:1182 --warnaserror:FS0025</OtherFlags>
-    <!-- <TreatWarningsAsErrors>true</TreatWarningsAsErrors> -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/Insurello.AsyncExtra/Insurello.AsyncExtra.fsproj
+++ b/src/Insurello.AsyncExtra/Insurello.AsyncExtra.fsproj
@@ -12,7 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
     <Compile Include="AsyncExtra.fs" />
   </ItemGroup>
+  <PropertyGroup>
+    <OtherFlags>$(OtherFlags) --warnon:1182 --warnaserror:FS0025</OtherFlags>
+    <!-- <TreatWarningsAsErrors>true</TreatWarningsAsErrors> -->
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
### Problem

On rare occasions we need to do processing on the error track, e.g. run a compensation action.

### Solution

Add a `bindError` convenience function.