### PR TITLE
Add fromUnitTask helper

### DIFF
--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -37,3 +37,17 @@ let tests =
               let! _actual = AsyncResult.sequence input
               Expect.equal orderRun expectedOkValue "Should be run in same order"
           } ]
+
+[<Tests>]]
+let taskTests =
+        testList "Task tests"
+            [ testAsync "should ... " {
+                let input = fun _ -> Async.singleton |> Async.StartAsTask
+
+                // let expectedValue = ()
+
+                let! actual = AsyncResult.fromTeeTask input
+
+                Expect.equal actual expectedValue
+            }]
+

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -46,48 +46,52 @@ let tests =
 let taskTests =
     testList
         "Task tests"
-        [ testAsync "should convert from Task<string> to AsyncResult" {
-              let input =
-                  Async.singleton "Hello" |> Async.StartAsTask
+        [ testList
+            "fromUnitTask"
+              [ testAsync "should convert from Task to AsyncResult" {
+                    let source = new CancellationTokenSource()
+                    let input: Task = Task.Delay(0, source.Token)
 
-              let expectedValue = Ok "Hello"
+                    let expectedValue = Ok()
 
-              let! actual = AsyncResult.fromTask input
+                    let! actual = AsyncResult.fromUnitTask input
 
-              Expect.equal actual expectedValue "Should be equal"
-          }
-          testAsync "fromTask failing Task should result in Error" {
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "failing Task should result in Error" {
+                    let source = new CancellationTokenSource()
+                    let input: Task = Task.Delay(1000, source.Token)
+                    let expectedValue = Error "A task was canceled."
 
-              let input =
-                  Async.singleton "Hello"
-                  |> Async.map (fun _ -> failwith "boom")
-                  |> Async.StartAsTask
+                    source.Cancel()
 
-              let expectedValue =
-                  Error "One or more errors occurred. (boom)"
+                    let! actual = AsyncResult.fromUnitTask input
 
-              let! actual = AsyncResult.fromTask input
+                    Expect.equal actual expectedValue "Should be equal"
+                } ]
+          testList
+              "fromTask"
+              [ testAsync "should convert from Task<string> to AsyncResult" {
+                    let input =
+                        Async.singleton "Hello" |> Async.StartAsTask
 
-              Expect.equal actual expectedValue "Should be equal"
-          }
-          testAsync "should convert from Task to AsyncResult" {
-              let source = new CancellationTokenSource()
-              let input: Task = Task.Delay(0, source.Token)
+                    let expectedValue = Ok "Hello"
 
-              let expectedValue = Ok()
+                    let! actual = AsyncResult.fromTask input
 
-              let! actual = AsyncResult.fromUnitTask input
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "fromTask failing Task should result in Error" {
 
-              Expect.equal actual expectedValue "Should be equal"
-          }
-          testAsync "failing Task should result in Error" {
-              let source = new CancellationTokenSource()
-              let input: Task = Task.Delay(1000, source.Token)
-              let expectedValue = Error "A task was canceled."
+                    let input =
+                        Async.singleton "Hello"
+                        |> Async.map (fun _ -> failwith "boom")
+                        |> Async.StartAsTask
 
-              source.Cancel()
+                    let expectedValue =
+                        Error "One or more errors occurred. (boom)"
 
-              let! actual = AsyncResult.fromUnitTask input
+                    let! actual = AsyncResult.fromTask input
 
-              Expect.equal actual expectedValue "Should be equal"
-          } ]
+                    Expect.equal actual expectedValue "Should be equal"
+                } ] ]

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -1,5 +1,7 @@
 module AsyncExtraTests
 
+open System.Threading
+open System.Threading.Tasks
 open Insurello.AsyncExtra
 open Expecto
 
@@ -38,16 +40,26 @@ let tests =
               Expect.equal orderRun expectedOkValue "Should be run in same order"
           } ]
 
-[<Tests>]]
+[<Tests>]
 let taskTests =
         testList "Task tests"
-            [ testAsync "should ... " {
-                let input = fun _ -> Async.singleton |> Async.StartAsTask
+            [ testAsync "should convert from Task<string> to AsyncResult" {
+                let input = Async.singleton "Hello" |> Async.StartAsTask
 
-                // let expectedValue = ()
+                let expectedValue = Ok "Hello"
 
-                let! actual = AsyncResult.fromTeeTask input
+                let! actual = AsyncResult.fromTask input
 
-                Expect.equal actual expectedValue
+                Expect.equal actual expectedValue "Should be equal"
+            }
+            ;testAsync "should convert from TeeTask to AsyncResult" {
+                let source = new CancellationTokenSource()
+                let input = Task.Delay(0, source.Token)
+                    
+                let expectedValue = Ok "Hello"
+
+                let! actual = AsyncResult.fromTask input
+
+                Expect.equal actual expectedValue "Should be equal"
             }]
 

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -30,7 +30,7 @@ module AsyncResult =
                 | Choice1Of2 response -> Ok response
                 | Choice2Of2 exn -> Error exn.Message)
 
-    let fromTeeTask: System.Threading.Tasks.Task -> AsyncResult<'x, string> =
+    let fromTeeTask: System.Threading.Tasks.Task -> AsyncResult<unit, string> =
         fun task ->
             task
             |> Async.AwaitTask
@@ -56,7 +56,10 @@ module AsyncResult =
     let sequence: AsyncResult<'x, 'error> list -> AsyncResult<'x list, 'error> =
         let folder: AsyncResult<'x list, 'error> -> AsyncResult<'x, 'error> -> AsyncResult<'x list, 'error> =
             fun acc nextAsyncResult ->
-                acc |> bind (fun okValues -> nextAsyncResult |> map (fun nextOkValue -> nextOkValue :: okValues))
+                acc
+                |> bind (fun okValues ->
+                    nextAsyncResult
+                    |> map (fun nextOkValue -> nextOkValue :: okValues))
 
         fun asyncs ->
             asyncs

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -30,6 +30,15 @@ module AsyncResult =
                 | Choice1Of2 response -> Ok response
                 | Choice2Of2 exn -> Error exn.Message)
 
+    let fromTeeTask: System.Threading.Tasks.Task -> AsyncResult<'x, string> =
+        fun task ->
+            task
+            |> Async.AwaitTask
+            |> Async.Catch
+            |> Async.map (function
+                | Choice1Of2 response -> Ok response
+                | Choice2Of2 exn -> Error exn.Message)
+
     let map: ('x -> 'y) -> AsyncResult<'x, 'err> -> AsyncResult<'y, 'err> =
         fun f asyncResultX -> Async.map (Result.map f) asyncResultX
 

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -30,7 +30,7 @@ module AsyncResult =
                 | Choice1Of2 response -> Ok response
                 | Choice2Of2 exn -> Error exn.Message)
 
-    let fromTeeTask: System.Threading.Tasks.Task -> AsyncResult<unit, string> =
+    let fromUnitTask: System.Threading.Tasks.Task -> AsyncResult<unit, string> =
         fun task ->
             task
             |> Async.AwaitTask


### PR DESCRIPTION
### Problem

C# `Task`s are implicitly `Task<unit>`, but the type declaration for `fromTask` doesn't allow `Task` without a `<'T>` type. This makes `fromTask` not work with `Task`.

### Solution

Create a separate `fromUnitTask` that takes `Task` instead of `Task<'T>`