### PR TITLE
Better AsyncResult.sequence test

### DIFF
--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -33,7 +33,8 @@ let tests =
                           j)
 
               let input =
-                  [ (dummyAsync 1)
+                  [ Async.Sleep 100
+                    |> Async.bind (fun _ -> dummyAsync 1)
                     (dummyAsync 2)
                     (dummyAsync 3) ]
 


### PR DESCRIPTION
### Problem
AsyncResult.sequence tests might "accidentally" pass because of bad implementation.

### Solution
Add delay to some tasks