### PR TITLE
Lazify AsyncResult.fromTask

### DIFF
--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -51,7 +51,7 @@ let taskTests =
             "fromUnitTask"
               [ testAsync "should convert from Task to AsyncResult" {
                     let source = new CancellationTokenSource()
-                    let input: Task = Task.Delay(0, source.Token)
+                    let input: (unit -> Task) = fun () -> Task.Delay(0, source.Token)
 
                     let expectedValue = Ok()
 
@@ -61,7 +61,7 @@ let taskTests =
                 }
                 testAsync "failing Task should result in Error" {
                     let source = new CancellationTokenSource()
-                    let input: Task = Task.Delay(1000, source.Token)
+                    let input = fun () -> Task.Delay(1000, source.Token)
                     let expectedValue = Error "A task was canceled."
 
                     source.Cancel()
@@ -74,7 +74,7 @@ let taskTests =
               "fromTask"
               [ testAsync "should convert from Task<string> to AsyncResult" {
                     let input =
-                        Async.singleton "Hello" |> Async.StartAsTask
+                        fun () -> Async.singleton "Hello" |> Async.StartAsTask
 
                     let expectedValue = Ok "Hello"
 
@@ -85,9 +85,10 @@ let taskTests =
                 testAsync "fromTask failing Task should result in Error" {
 
                     let input =
-                        Async.singleton "Hello"
-                        |> Async.map (fun _ -> failwith "boom")
-                        |> Async.StartAsTask
+                        fun () ->
+                            Async.singleton "Hello"
+                            |> Async.map (fun _ -> failwith "boom")
+                            |> Async.StartAsTask
 
                     let expectedValue =
                         Error "One or more errors occurred. (boom)"

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -21,19 +21,17 @@ module AsyncResult =
             | None -> Error err
             |> fromResult
 
-    let fromTask: System.Threading.Tasks.Task<'x> -> AsyncResult<'x, string> =
-        fun task ->
-            task
-            |> Async.AwaitTask
+    let fromTask: (unit -> System.Threading.Tasks.Task<'x>) -> AsyncResult<'x, string> =
+        fun lazyTask ->
+            async.Delay(lazyTask >> Async.AwaitTask)
             |> Async.Catch
             |> Async.map (function
                 | Choice1Of2 response -> Ok response
                 | Choice2Of2 exn -> Error exn.Message)
 
-    let fromUnitTask: System.Threading.Tasks.Task -> AsyncResult<unit, string> =
-        fun task ->
-            task
-            |> Async.AwaitTask
+    let fromUnitTask: (unit -> System.Threading.Tasks.Task) -> AsyncResult<unit, string> =
+        fun lazyTask ->
+            async.Delay(lazyTask >> Async.AwaitTask)
             |> Async.Catch
             |> Async.map (function
                 | Choice1Of2 response -> Ok response


### PR DESCRIPTION
### Problem
Tasks are eager and start computing as soon as they are instantiated but we want them to start computing when they are called later inside AsyncResult evaluation. 

### Solution
Use async.Delay to delay the execution of Tasks.