### PR TITLE
AsyncResult CE 

### DIFF
--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -10,16 +10,14 @@ let tests =
     testList
         "Sequence tests"
         [ testAsync "should return values in same order as given tasks" {
-              let dummyAsync: int -> AsyncResult<int, string> = Ok >> AsyncResult.fromResult
+              let sample = [ 1; 2; 3 ]
 
-              let expected = Ok [ 1; 2; 3 ]
+              let expected = Ok sample
 
-              let input =
-                  [ (dummyAsync 1)
-                    (dummyAsync 2)
-                    (dummyAsync 3) ]
+              let input = List.map AsyncResult.singleton sample
 
               let! actual = AsyncResult.sequence input
+
               Expect.equal actual expected "should equal"
           }
           testAsync "should execute async task in sequence" {

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -1,6 +1,6 @@
 namespace Insurello.AsyncExtra
 
-[<RequireQualifiedAccessAttribute>]
+[<RequireQualifiedAccess>]
 module Async =
     let singleton: 'value -> Async<'value> = async.Return
 
@@ -10,7 +10,7 @@ module Async =
 
 type AsyncResult<'x, 'err> = Async<Result<'x, 'err>>
 
-[<RequireQualifiedAccessAttribute>]
+[<RequireQualifiedAccess>]
 module AsyncResult =
     let fromResult: Result<'x, 'err> -> AsyncResult<'x, 'err> = Async.singleton
 

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -67,3 +67,88 @@ module AsyncResult =
             asyncs
             |> List.fold folder (fromResult (Ok []))
             |> map List.rev
+
+    let singleton: 'value -> AsyncResult<'value, 'e> = fun x -> Async.singleton (Ok x)
+
+    let fromAsync: Async<'x> -> AsyncResult<'x, string> =
+        fun async ->
+            async
+            |> Async.Catch
+            |> Async.map (function
+                | Choice1Of2 response -> Ok response
+                | Choice2Of2 exn -> Error exn.Message)
+
+    let andMap: AsyncResult<'a, 'e> -> AsyncResult<('a -> 'b), 'e> -> AsyncResult<'b, 'e> =
+        fun asyncResult f ->
+            async {
+                let! execF = Async.StartChild f
+
+                let! execAsyncResult = Async.StartChild asyncResult
+
+                let! f' = execF
+
+                let! asyncResult' = execAsyncResult
+
+                return match f', asyncResult' with
+                       | Ok fOk, Ok aROk -> Ok(fOk aROk)
+                       | Error e, _ -> Error e
+                       | _, Error e -> Error e
+            }
+
+    let zip: AsyncResult<'a, 'e> -> AsyncResult<'b, 'e> -> AsyncResult<('a * 'b), 'e> =
+        fun async1 async2 ->
+            (fun a b -> a, b)
+            |> singleton
+            |> andMap async1
+            |> andMap async2
+
+[<AutoOpen>]
+module AsyncResultCE =
+    type AsyncResultBuilder() =
+        member _.Return(value: 'a): AsyncResult<'a, 'e> = AsyncResult.singleton value
+
+        member _.ReturnFrom(asyncResult: AsyncResult<'a, 'e>): AsyncResult<'a, 'e> = asyncResult
+
+        member _.Zero(): AsyncResult<unit, 'e> = AsyncResult.singleton ()
+
+        member _.Bind(asyncResult: AsyncResult<'a, 'e>, f: 'a -> AsyncResult<'b, 'e>): AsyncResult<'b, 'e> =
+            AsyncResult.bind f asyncResult
+
+        member _.Delay(f: unit -> AsyncResult<'a, 'e>): AsyncResult<'a, 'e> = async.Delay f
+
+        member _.Combine(unitAsyncResult: AsyncResult<unit, 'e>, asyncResult: AsyncResult<'a, 'e>)
+                         : AsyncResult<'a, 'e> =
+            AsyncResult.bind (fun () -> asyncResult) unitAsyncResult
+
+        member _.TryWith(asyncResult: AsyncResult<'a, 'e>, f: exn -> AsyncResult<'a, 'e>): AsyncResult<'a, 'e> =
+            async.TryWith(asyncResult, f)
+
+        member _.TryFinally(asyncResult: AsyncResult<'a, 'e>, f: unit -> unit): AsyncResult<'a, 'e> =
+            async.TryFinally(asyncResult, f)
+
+        member _.Using(disposable: 'a :> System.IDisposable, f: 'a -> AsyncResult<'b, 'e>): AsyncResult<'b, 'e> =
+            async.Using(disposable, f)
+
+        member _.BindReturn(asyncResult: AsyncResult<'a, 'e>, f: 'a -> 'b): AsyncResult<'b, 'e> =
+            AsyncResult.map f asyncResult
+
+        member _.MergeSources(asyncResult1: AsyncResult<'a, 'e>, asyncResult2: AsyncResult<'b, 'e>)
+                              : AsyncResult<'a * 'b, 'e> =
+            AsyncResult.zip asyncResult1 asyncResult2
+
+        member inline _.Source(asyncResult: AsyncResult<'a, 'e>): AsyncResult<'a, 'e> = asyncResult
+
+    let asyncResult = AsyncResultBuilder()
+
+[<AutoOpen>]
+module AsyncResultCEExtensions =
+    type AsyncResultBuilder with
+        member inline _.Source(asyncOp: Async<'a>): AsyncResult<'a, string> = AsyncResult.fromAsync asyncOp
+
+        member inline _.Source(result: Result<'a, 'e>): AsyncResult<'a, 'e> = AsyncResult.fromResult result
+
+        member inline _.Source(task: System.Threading.Tasks.Task<'a>): AsyncResult<'a, string> =
+            AsyncResult.fromTask (fun () -> task)
+
+        member inline _.Source(unitTask: System.Threading.Tasks.Task): AsyncResult<unit, string> =
+            AsyncResult.fromUnitTask (fun () -> unitTask)


### PR DESCRIPTION
### Problem 

Not having an adequate AsyncResult Builder, and having to use it from a helper package or from other packages ([FSharp.Prelude](https://github.com/jamil7/FSharp.Prelude)), which makes everything feel disconnected.

I actually found a small bug too. 
[\<RequireQualifiedAccessAttribute\>] can't be used on modules, thus rendered useless. 
### Solution 

AsyncResult Builder implementation + helper functions.

[\<RequireQualifiedAccess\>] should be used instead.

### Features
 - CE can handle Asyncs, Results, and Tasks with `let!`
 - CE has support for parallel execution with `and!` (applicative style)
 - andMap can run stuff in parallel, and removes the need for `map2`, `map3`... albeit being a little more verbose to use (see [zip](https://github.com/insurello/Insurello.AsyncExtra/blob/63b9bd2fd662055c2fc9804496d0b39e002adb31/src/Insurello.AsyncExtra/AsyncExtra.fs#L98)'s implementation) 

### Reason to use this
TBH there is only one: ease of use. 
The amount of thinking about whether to bind or to map, to write pipes, and align lambdas inside lambdas is better spent on solving real issues. 

### How to use
 - If you need a value wrapped in an `Async`, `Result`, `Task`, or `AsyncResult`, just put a `let!` before it. 
 - If you have two or more values wrapped in the aforementioned types that you want to unwrap, and the values are independent of each other , put a `let!` on the first, and `and!` on the ones that follow. Don't panic if you do something you're not supposed to the compiler will let you know.
 -  If you have a `unit` as value wrapped in the aforementioned wrappers you can use `do!`
 - You always need to return something with the `return` keyword
 - You can return and bind with `return!` (often used as bind id)
 - You can match and bind with `match!`
 - `if` statements don't need an `else` branch, they will return `AsyncResult (Ok ())` on the else branch by default
There are some more advanced tips, and tricks. Feel free to ask about them.

### Things to keep in mind
 - Errors look ambiguous at first, but they are pretty easy to understand after the first time
 - The most common error is not having the same `Error` type in all `let!`s. Remember these work as a normal bind, and expect the same error types. The solution is just to use `|> AsyncResult.mapError()` as usual. 

### Examples from production code
 - [Ex1](https://github.com/insurello/insurello-exp/blob/481cd611b00db3e20ed470f794aac2fcb4cb175a/workflows/admin-api/Denmark/ViewCombiners.fs#L34)
 - [Ex2](https://github.com/insurello/insurello-exp/blob/481cd611b00db3e20ed470f794aac2fcb4cb175a/workflows/BackgroundJobs/Program.fs#L153)
 - [Ex3](https://github.com/insurello/insurello-exp/blob/481cd611b00db3e20ed470f794aac2fcb4cb175a/workflows/CustomerCommunication/Actions.fs#L112)
 - [Ex4 this was very ugly before AR CE](https://github.com/insurello/insurello-exp/blob/481cd611b00db3e20ed470f794aac2fcb4cb175a/workflows/signup/Denmark/Signup.fs#L170)

### Lastly
The code needs some clean up, like moving the grouping some functions together. If this is approved I'll make it prettier before merging.