### PR TITLE
Add useful helper functions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 5.0.102
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ AsyncResult.map increase eA // Async<Error 2>
 mapError : ('errX -> 'errY) -> AsyncResult<'a, 'errX> -> AsyncResult<'a, 'errY>
 ```
 
-Similar to `map` but will instead apply the transformation function to the `Error`.
+Similar to [`map`](#map) but will instead apply the transformation function to the `Error`.
 
 ##### bind
 
@@ -163,7 +163,7 @@ Similar to `map` but will instead apply the transformation function to the `Erro
 bind : ('a -> AsyncResult<'b, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err>
 ```
 
-Sometimes you want to use a transform function that will return an `AsyncResult` but you don't want to end up with a nested `AsyncResult<AsyncResult<'b, 'err>, 'err>`. This is where `bind` shines. It will transform the value, in the same way as `map`, but will flatten the returning `AsyncResult` and will return an `AsyncResult<'b, 'err>`. `Bind` is also known as `andThen` in Elm and `chain` in JavaScript.
+Sometimes you want to use a transform function that will return an `AsyncResult` but you don't want to end up with a nested `AsyncResult<AsyncResult<'b, 'err>, 'err>`. This is where `bind` shines. It will transform the value, in the same way as [`map`](#map), but will flatten the returning `AsyncResult` and will return an `AsyncResult<'b, 'err>`. `Bind` is also known as `andThen` in Elm and `chain` in JavaScript.
 
 ```fsharp
 fetchUser : int -> AsyncResult<User, string>
@@ -185,7 +185,7 @@ fetchUser 4 // Async<Ok { name: "The Grinch"; friends: [] }>
 bindError : ('errX -> AsyncResult<'a, 'errY>) -> AsyncResult<'a, 'errX> -> AsyncResult<'a, 'errY>
 ```
 
-Similar to `bind` but will instead apply the AsyncResult returning transformation function to the `Error`.
+Similar to [`bind`](#bind) but will instead apply the AsyncResult returning transformation function to the `Error`.
 
 ##### apply
 
@@ -220,7 +220,7 @@ AsyncResult.map2 add xA yA // Async<Ok 7>
 map3 : ('a -> 'b -> 'c -> 'd) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err>
 ```
 
-Solves the same problem as `map2` but for three arguments.
+Solves the same problem as [`map2`](#map2) but for three arguments.
 
 ##### map4
 
@@ -228,7 +228,7 @@ Solves the same problem as `map2` but for three arguments.
 map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err>
 ```
 
-Solves the same problem as `map2` but for four arguments.
+Solves the same problem as [`map2`](#map2) but for four arguments.
 
 ##### map5
 
@@ -236,7 +236,7 @@ Solves the same problem as `map2` but for four arguments.
 map5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err>
 ```
 
-Solves the same problem as `map2` but for five arguments.
+Solves the same problem as [`map2`](#map2) but for five arguments.
 
 ##### andMap
 
@@ -244,7 +244,7 @@ Solves the same problem as `map2` but for five arguments.
 andMap : AsyncResult<'a, 'err> -> AsyncResult<('a -> 'b), 'err> -> AsyncResult<'b, 'err>
 ```
 
-In most cases `map2`-`map5` should be enough but in those cases you want to apply more arguments you can use `andMap`. Technically, `andMap` is the same as `apply` but the order of the arguments are reversed. While `apply` takes the function first and then the value, `andMap` takes the value first and then the function. This allow you to have a similar structure to your code as you would have using `mapX`.
+In most cases `map2`-`map5` should be enough but in those cases you want to apply more arguments you can use `andMap`. Technically, `andMap` is the same as [`apply`](#apply) but the order of the arguments are reversed. While `apply` takes the function first and then the value, `andMap` takes the value first and then the function. This allow you to have a similar structure to your code as you would have using `mapX`.
 
 ```fsharp
 let add3 = AsyncResult.singleton (fun a b c -> a + b + c)
@@ -265,7 +265,7 @@ add3 // Async<Ok (fun a b c -> a + b + c)>
 bind2 : ('a -> 'b -> AsyncResult<'c, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err>
 ```
 
-You can use `bind2` to solve the same problem as `map2` if your transformation function returns an `AsyncResult`. In other words, their relationship is the same as `map` and `bind`.
+You can use `bind2` to solve the same problem as [`map2`](#map2) if your transformation function returns an `AsyncResult`. In other words, their relationship is the same as `map` and `bind`.
 
 ##### bind3
 
@@ -273,7 +273,7 @@ You can use `bind2` to solve the same problem as `map2` if your transformation f
 bind3 : ('a -> 'b -> 'c -> AsyncResult<'d, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err>
 ```
 
-Solves the same problem as `bind2` but for three arguments.
+Solves the same problem as [`bind2`](#bind2) but for three arguments.
 
 ##### bind4
 
@@ -281,7 +281,7 @@ Solves the same problem as `bind2` but for three arguments.
 bind4 : ('a -> 'b -> 'c -> 'd -> AsyncResult<'e, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err>
 ```
 
-Solves the same problem as `bind2` but for four arguments.
+Solves the same problem as [`bind2`](#bind2) but for four arguments.
 
 ##### bind5
 
@@ -289,7 +289,7 @@ Solves the same problem as `bind2` but for four arguments.
 bind5 : ('a -> 'b -> 'c -> 'd -> 'e -> AsyncResult<'f, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err>
 ```
 
-Solves the same problem as `bind2` but for five arguments.
+Solves the same problem as [`bind2`](#bind2) but for five arguments.
 
 #### Lists
 
@@ -315,7 +315,7 @@ userIds // [1; 2; 3]
 traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err>
 ```
 
-Similar to `sequence`, `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform each value in the list of `AsyncResult`.
+Similar to [`sequence`](#sequence), `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform each value in the list of `AsyncResult`.
 
 By sending in `id` as the transform function you have implemented `sequence`. Let's have a look how we can solve the example in the `sequence` description using `traverse` instead.
 
@@ -327,7 +327,3 @@ AsyncResult.traverse fetchUser userIds// Async<Ok [User, User, User]>
 ```
 
 [![Insurello](https://gitcdn.xyz/repo/insurello/elm-swedish-bank-account-number/master/insurello.svg)](https://jobb.insurello.se/departments/product-tech)
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The functions need to be prefixed with `AsyncResult.`.
 singleton : 'a -> AsyncResult<'a, 'err>
 ```
 
-The easiest way to create a new `AsyncResult`.
+The easiest way to create a new `AsyncResult` with an `Ok` value.
 
 ##### fromResult
 
@@ -110,7 +110,7 @@ Convert a `Result` into a `AsyncResult`.
 fromOption : 'err -> Option<'a> -> AsyncResult<'a, 'err>
 ```
 
-Convert an `Option` into a `AsyncResult`. You need to first provide the `Error` value that should be used if the option is `None`.
+Convert an `Option` into an `AsyncResult`. The first argument is the `Error` value that should be used if the option is `None`.
 
 ##### fromTask
 
@@ -161,7 +161,7 @@ fetchUser : int -> AsyncResult<User, string>
 fetchFriends : User -> AsyncResult<string list, string>
 
 fetchUser 1 // Async<Ok { name: "Mary"; friends: [2; 3] }>
-|> AsyncResult.bind fetchFriends // Async<Ok ["Peter"; "John"]>
+|> AsyncResult.bind fetchFriends // Async<Ok ["Peter"; "Paul"]>
 
 fetchUser 5 // Async<Error "Can't find a user with that id">
 |> AsyncResult.bind fetchFriends // Will never run
@@ -244,10 +244,10 @@ let xA = AsyncResult.singleton 10
 let yA = AsyncResult.singleton 20
 let zA = AsyncResult.singleton 30
 
-add3 // Ok (fun a b c -> a + b + c)
-|> AsyncResult.andMap xA // Ok (fun b c -> 10 + b + c)
-|> AsyncResult.andMap yA // Ok (fun c -> 10 + 20 + c)
-|> AsyncResult.andMap zA // OK 60
+add3 // Async<Ok (fun a b c -> a + b + c)>
+|> AsyncResult.andMap xA // Async<Ok (fun b c -> 10 + b + c)>
+|> AsyncResult.andMap yA // Async<Ok (fun c -> 10 + 20 + c)>
+|> AsyncResult.andMap zA // Async<OK 60>
 ```
 
 ##### bind2
@@ -256,7 +256,7 @@ add3 // Ok (fun a b c -> a + b + c)
 bind2 : ('a -> 'b -> AsyncResult<'c, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err>
 ```
 
-You can use `bind2` to the same problem as `map2` if your transformation function returns an `AsyncResult`. In other words, their relationship is the same as `map` and `bind`.
+You can use `bind2` to solve the same problem as `map2` if your transformation function returns an `AsyncResult`. In other words, their relationship is the same as `map` and `bind`.
 
 ##### bind3
 
@@ -306,7 +306,7 @@ userIds // [1; 2; 3]
 traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err>
 ```
 
-Similar to `sequence`, `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform the each value in the list of `AsyncResult`.
+Similar to `sequence`, `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform each value in the list of `AsyncResult`.
 
 By sending in `id` as the transform function you have implemented `sequence`. Let's have a look how we can solve the example in the `sequence` description using `traverse` instead.
 

--- a/README.md
+++ b/README.md
@@ -82,4 +82,243 @@ let firstPersonsNameWithAsyncResult: unit -> AsyncResult<string, string> =
 
 ```
 
+### Function documentation
+
+The functions need to be prefixed with `AsyncResult.`.
+
+#### Construction
+
+##### singleton
+
+```fsharp
+singleton : 'a -> AsyncResult<'a, 'err>
+```
+
+The easiest way to create a new `AsyncResult`.
+
+##### fromResult
+
+```fsharp
+fromResult : Result<'a, 'err> -> AsyncResult<'a, 'err>
+```
+
+Convert a `Result` into a `AsyncResult`.
+
+##### fromOption
+
+```fsharp
+fromOption : 'err -> Option<'a> -> AsyncResult<'a, 'err>
+```
+
+Convert an `Option` into a `AsyncResult`. You need to first provide the `Error` value that should be used if the option is `None`.
+
+##### fromTask
+
+```fsharp
+fromTask : (unit -> System.Threading.Tasks.Task<'a>) -> AsyncResult<'a, string>
+```
+
+Convert a `Task` with a value into a `AsyncResult`.
+
+##### fromUnitTask
+
+```fsharp
+fromUnitTask : (unit -> System.Threading.Tasks.Task) -> AsyncResult<unit, string>
+```
+
+Convert a unit `Task` into a `AsyncResult`.
+
+#### Transformation
+
+##### map
+
+```fsharp
+map : ('a -> 'b) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err>
+```
+
+Used to apply transformations to `Ok` values of an `AsyncResult`, `map` takes a function that it will lift into the context of the `AsyncResult` and apply to it the wrapped value. A new `AsyncResult` with the transformed value will be returned. If the instance contains an `Error` the transformation function will never be applied.
+
+If the transform function will return an `AsyncResult` you might want to use `bind` instead.
+
+##### mapError
+
+```fsharp
+mapError : ('errX -> 'errY) -> AsyncResult<'a, 'errX> -> AsyncResult<'a, 'errY>
+```
+
+Similar to `map` but will instead apply the transformation function to the `Error`.
+
+##### bind
+
+```fsharp
+bind : ('a -> AsyncResult<'b, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err>
+```
+
+Sometimes you want to use a transform function that will return an `AsyncResult` but you don't want to end up with a nested `AsyncResult<AsyncResult<'b, 'err>, 'err>`. This is where `bind` shines. It will transform the value, in the same way as `map`, but will flatten the returning `AsyncResult` and will return an `AsyncResult<'b, 'err>`. `Bind` is also known as `andThen` in Elm and `chain` in JavaScript.
+
+```fsharp
+fetchUser : int -> AsyncResult<User, string>
+fetchFriends : User -> AsyncResult<string list, string>
+
+fetchUser 1 // Async<Ok { name: "Mary"; friends: [2; 3] }>
+|> AsyncResult.bind fetchFriends // Async<Ok ["Peter"; "John"]>
+
+fetchUser 5 // Async<Error "Can't find a user with that id">
+|> AsyncResult.bind fetchFriends // Will never run
+
+fetchUser 4 // Async<Ok { name: "The Grinch"; friends: [] }>
+|> AsyncResult.bind fetchFriends // Async<Error "Can't find any friends">
+```
+
+##### bindError
+
+```fsharp
+bindError : ('errX -> AsyncResult<'a, 'errY>) -> AsyncResult<'a, 'errX> -> AsyncResult<'a, 'errY>
+```
+
+Similar to `bind` but will instead apply the AsyncResult returning transformation function to the `Error`.
+
+##### apply
+
+```fsharp
+apply : AsyncResult<('a -> 'b), 'err> -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err>
+```
+
+Is used to apply a `AsyncResult` value to a function in an `AsyncResult`.
+
+When either `AsyncResult` is `Error`, apply will return a new `Error` instance containing the `Error` value. This can be used to safely combine multiple values under a given combination function. If any of the inputs result in an `Error` then the computation will return an `Error` `AsyncResult`.
+
+##### map2
+
+```fsharp
+map2 : ('a -> 'b -> 'c) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err>
+```
+
+Sometimes you want to transform the result of two `AsyncResult`. This is were `map2` comes into play. It requires a transformation function that is expecting two arguments. The order of the arguments are determined by the order of the two `AsyncResult`. The first value is applied first and the second value is applied as the second argument.
+
+```fsharp
+let add x y = x + y
+
+let xA = AsyncResult.singleton 3
+let yA = AsyncResult.singleton 4
+
+AsyncResult.map2 add xA yA // Async<Ok 7>
+```
+
+##### map3
+
+```fsharp
+map3 : ('a -> 'b -> 'c -> 'd) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err>
+```
+
+Solves the same problem as `map2` but for three arguments.
+
+##### map4
+
+```fsharp
+map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err>
+```
+
+Solves the same problem as `map2` but for four arguments.
+
+##### map5
+
+```fsharp
+map5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err>
+```
+
+Solves the same problem as `map2` but for five arguments.
+
+##### andMap
+
+```fsharp
+andMap : AsyncResult<'a, 'err> -> AsyncResult<('a -> 'b), 'err> -> AsyncResult<'b, 'err>
+```
+
+In most cases `map2`-`map5` should be enough but in those cases you want to apply more arguments you can use `andMap`. Technically, `andMap` is the same as `apply` but the order of the arguments are reversed. While `apply` takes the function first and then the value, `andMap` takes the value first and then the function. This allow you to have a similar structure to your code as you would have using `mapX`.
+
+```fsharp
+let add3 = AsyncResult.singleton (fun a b c -> a + b + c)
+
+let xA = AsyncResult.singleton 10
+let yA = AsyncResult.singleton 20
+let zA = AsyncResult.singleton 30
+
+add3 // Ok (fun a b c -> a + b + c)
+|> AsyncResult.andMap xA // Ok (fun b c -> 10 + b + c)
+|> AsyncResult.andMap yA // Ok (fun c -> 10 + 20 + c)
+|> AsyncResult.andMap zA // OK 60
+```
+
+##### bind2
+
+```fsharp
+bind2 : ('a -> 'b -> AsyncResult<'c, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err>
+```
+
+You can use `bind2` to the same problem as `map2` if your transformation function returns an `AsyncResult`. In other words, their relationship is the same as `map` and `bind`.
+
+##### bind3
+
+```fsharp
+bind3 : ('a -> 'b -> 'c -> AsyncResult<'d, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err>
+```
+
+Solves the same problem as `bind2` but for three arguments.
+
+##### bind4
+
+```fsharp
+bind4 : ('a -> 'b -> 'c -> 'd -> AsyncResult<'e, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err>
+```
+
+Solves the same problem as `bind2` but for four arguments.
+
+##### bind5
+
+```fsharp
+bind5 : ('a -> 'b -> 'c -> 'd -> 'e -> AsyncResult<'f, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err>
+```
+
+Solves the same problem as `bind2` but for five arguments.
+
+#### Lists
+
+##### sequence
+
+```fsharp
+sequence : List<AsyncResult<'a, 'error>> -> AsyncResult<'a list, 'error>
+```
+
+From time to time you will find yourself having a list of `AsyncResult` (`List<AsyncResult<'a, 'err>`) but you would rather have an `AsyncResult` with a list of values (`AsyncResult<'a list, 'error>`). In those cases `sequence` can help you.
+
+```fsharp
+fetchUser : int -> AsyncResult<User, string>
+
+userIds // [1; 2; 3]
+|> List.map fetchUser // [Async<Ok User>, Async<Ok User>, Async<Ok User>]
+|> AsyncResult.sequence // Async<Ok [User, User, User]>
+```
+
+##### traverse
+
+```fsharp
+traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err>
+```
+
+Similar to `sequence`, `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform the each value in the list of `AsyncResult`.
+
+By sending in `id` as the transform function you have implemented `sequence`. Let's have a look how we can solve the example in the `sequence` description using `traverse` instead.
+
+```fsharp
+fetchUser : int -> AsyncResult<User, string>
+let userIds = [1; 2; 3]
+
+AsyncResult.traverse fetchUser userIds// Async<Ok [User, User, User]>
+```
+
 [![Insurello](https://gitcdn.xyz/repo/insurello/elm-swedish-bank-account-number/master/insurello.svg)](https://jobb.insurello.se/departments/product-tech)
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -136,9 +136,18 @@ Convert a unit `Task` into a `AsyncResult`.
 map : ('a -> 'b) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err>
 ```
 
-Used to apply transformations to `Ok` values of an `AsyncResult`, `map` takes a function that it will lift into the context of the `AsyncResult` and apply to it the wrapped value. A new `AsyncResult` with the transformed value will be returned. If the instance contains an `Error` the transformation function will never be applied.
+You will most likely want to change the value in the `AsyncResult` by running functions. This is where `map` comes in handy. You send in a transformation function that will transform the value and `map` will then take the value from your `AsyncResult` run the function and return a brand new `AsyncResult` containing the new value. Worth keeping in mind is that the transformation function will only run if there is an `Ok` `AsyncResult`. If the `AsyncResult` contains an `Error` nothing will happen.
 
-If the transform function will return an `AsyncResult` you might want to use `bind` instead.
+If the transform function will return an `AsyncResult` you might want to use [`bind`](#bind) instead.
+
+```fsharp
+let increase x = x + 1
+let xA = AsyncResult.singleton 2
+let eA = AsyncResult.fromResult (Error 2)
+
+AsyncResult.map increase xA // Async<Ok 3>
+AsyncResult.map increase eA // Async<Error 2>
+```
 
 ##### mapError
 

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -541,4 +541,71 @@ let bindTests =
 
                     Expect.equal actual expected "Should be equal"
 
+                } ]
+
+          testList
+              "bind3"
+              [ testAsync "should map over the value from three AsyncResult" {
+                  let input1 = toAsyncResult 3
+                  let input2 = toAsyncResult 7
+                  let input3 = toAsyncResult 32
+                  let f a b c = toAsyncResult (a + b + c)
+
+                  let expectedValue = Ok 42
+
+                  let! actual = AsyncResult.bind3 f input1 input2 input3
+
+                  Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the first AsyncResult is an error" {
+                    let input1 = AsyncResult.fromResult (Error "Not Ok")
+                    let input2 = toAsyncResult 3
+                    let input3 = toAsyncResult 32
+                    let f a b c = toAsyncResult (a + b + c)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind3 f input1 input2 input3
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the second AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+                    let input2 = AsyncResult.fromResult (Error "Not Ok")
+                    let input3 = toAsyncResult 4
+                    let f a b c = toAsyncResult (a + b + c)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind3 f input1 input2 input3
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the third AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 4
+                    let input3 = AsyncResult.fromResult (Error "Not Ok")
+                    let f a b c = toAsyncResult (a + b + c)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind3 f input1 input2 input3
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should pass arguments in order" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 7
+                    let input3 = toAsyncResult 99
+
+                    let expected = Ok(3, 7, 99)
+
+                    let! actual = AsyncResult.bind3 (fun a b c -> toAsyncResult (a, b, c)) input1 input2 input3
+
+                    Expect.equal actual expected "Should be equal"
+
                 } ] ]

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -695,4 +695,21 @@ let bindTests =
 
                     Expect.equal actual expected "Should be equal"
 
+                } ]
+
+          testList
+              "bind5"
+              [ testAsync "should map over the value from five AsyncResult" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 7
+                    let input3 = toAsyncResult 32
+                    let input4 = toAsyncResult 10
+                    let input5 = toAsyncResult 115
+                    let f a b c d e = toAsyncResult (a + b + c + d + e)
+
+                    let expectedValue = Ok 167
+
+                    let! actual = AsyncResult.bind5 f input1 input2 input3 input4 input5
+
+                    Expect.equal actual expectedValue "Should be equal"
                 } ] ]

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -7,54 +7,27 @@ open Expecto
 
 [<Tests>]
 let creationTests =
+    let testSingleton text value =
+        testAsync text {
+            let! actual = AsyncResult.singleton value
+            let expected = Ok value
+
+            Expect.equal actual expected "should equal"
+        }
+
     testList
         "Test creating new AsyncResult"
         [ testList
               "singleton"
-              [ testAsync "should create an Ok AsyncResult given a string" {
-                  let value = "test"
+              [ testSingleton "should create an Ok AsyncResult given a string" "test"
 
-                  let! actual = AsyncResult.singleton value
-                  let expected = Ok value
+                testSingleton "should create an Ok AsyncResult given an int" 4
 
-                  Expect.equal actual expected "should equal"
-                }
+                testSingleton "should create an Ok AsyncResult given a bool" true
 
-                testAsync "should create an Ok AsyncResult given an int" {
-                    let value = 4
+                testSingleton "should nest Ok in a Ok AsyncResult" (Ok 1)
 
-                    let! actual = AsyncResult.singleton value
-                    let expected = Ok value
-
-                    Expect.equal actual expected "should equal"
-                }
-
-                testAsync "should create an Ok AsyncResult given a bool" {
-                    let value = true
-
-                    let! actual = AsyncResult.singleton value
-                    let expected = Ok value
-
-                    Expect.equal actual expected "should equal"
-                }
-
-                testAsync "should nest Ok in a Ok AsyncResult" {
-                    let value = Ok 1
-
-                    let! actual = AsyncResult.singleton value
-                    let expected = Ok value
-
-                    Expect.equal actual expected "should equal"
-                }
-
-                testAsync "should nest Error in a Ok AsyncResult" {
-                    let value = Error "This is in an Ok"
-
-                    let! actual = AsyncResult.singleton value
-                    let expected = Ok value
-
-                    Expect.equal actual expected "should equal"
-                } ] ]
+                testSingleton "should nest Error in a Ok AsyncResult" (Error "This is in an Ok") ] ]
 
 [<Tests>]
 let sequenceTests =

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -194,7 +194,7 @@ let applyTest =
 [<Tests>]
 let mapTests =
     testList
-        "Test mapping functions"
+        "Test map functions"
         [ testList
             "map"
             [ testAsync "should change the value in an AsyncResult" {
@@ -461,4 +461,34 @@ let mapTests =
                         |> AsyncResult.andMap zA
 
                     Expect.equal actual expected "Should be equal"
+                } ] ]
+
+[<Tests>]
+let bindTests =
+    testList
+        "Test bind functions"
+        [ testList
+              "bind"
+              [ testAsync "should change the value in an AsyncResult" {
+                  let input = toAsyncResult 3
+
+                  let f = ((+) 1 >> toAsyncResult)
+
+                  let expectedValue = Ok 4
+
+                  let! actual = AsyncResult.bind f input
+
+                  Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should NOT change the value in an Error AsyncResult" {
+                    let input = AsyncResult.fromResult (Error 3)
+
+                    let f = (+) 1 >> Ok >> AsyncResult.fromResult
+
+                    let expectedValue = Error 3
+
+                    let! actual = AsyncResult.bind f input
+
+                    Expect.equal actual expectedValue "Should be equal"
                 } ] ]

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -5,32 +5,35 @@ open System.Threading.Tasks
 open Insurello.AsyncExtra
 open Expecto
 
+let toAsyncResult<'x> : 'x -> AsyncResult<'x, string> = Ok >> AsyncResult.fromResult
+
 [<Tests>]
-let tests =
+let sequenceTests =
     testList
         "Sequence tests"
         [ testAsync "should return values in same order as given tasks" {
-              let dummyAsync: int -> AsyncResult<int, string> = Ok >> AsyncResult.fromResult
+            let dummyAsync : int -> AsyncResult<int, string> = Ok >> AsyncResult.fromResult
 
-              let expected = Ok [ 1; 2; 3 ]
+            let expected = Ok [ 1; 2; 3 ]
 
-              let input =
-                  [ (dummyAsync 1)
-                    (dummyAsync 2)
-                    (dummyAsync 3) ]
+            let input =
+                [ (dummyAsync 1)
+                  (dummyAsync 2)
+                  (dummyAsync 3) ]
 
-              let! actual = AsyncResult.sequence input
-              Expect.equal actual expected "should equal"
+            let! actual = AsyncResult.sequence input
+            Expect.equal actual expected "should equal"
           }
           testAsync "should execute async task in sequence" {
               let mutable orderRun = []
 
-              let dummyAsync: int -> AsyncResult<int, string> =
+              let dummyAsync : int -> AsyncResult<int, string> =
                   fun i ->
                       AsyncResult.fromResult (Ok i)
-                      |> AsyncResult.map (fun j ->
-                          orderRun <- List.append orderRun [ j ]
-                          j)
+                      |> AsyncResult.map
+                          (fun j ->
+                              orderRun <- List.append orderRun [ j ]
+                              j)
 
               let input =
                   [ Async.Sleep 100
@@ -44,43 +47,93 @@ let tests =
           } ]
 
 [<Tests>]
+let traverseTests =
+    testList
+        "Traverse tests"
+        [ testAsync "should return values in same order as given tasks" {
+            let expected = Ok [ 1; 2; 3 ]
+
+            let input =
+                [ (toAsyncResult 1)
+                  (toAsyncResult 2)
+                  (toAsyncResult 3) ]
+
+            let! actual = AsyncResult.traverse id input
+            Expect.equal actual expected "should equal"
+          }
+          testAsync "should return map the AsyncResult values" {
+              let transformer = ((+) 10)
+
+              let expected = Ok [ 11; 12; 13 ]
+
+              let input =
+                  [ (toAsyncResult 1)
+                    (toAsyncResult 2)
+                    (toAsyncResult 3) ]
+
+              let! actual = AsyncResult.traverse transformer input
+              Expect.equal actual expected "should equal"
+          }
+          testAsync "should execute async task in sequence" {
+              let mutable orderRun = []
+
+              let dummyAsync : int -> AsyncResult<int, string> =
+                  fun i ->
+                      AsyncResult.fromResult (Ok i)
+                      |> AsyncResult.map
+                          (fun j ->
+                              orderRun <- List.append orderRun [ j ]
+                              j)
+
+              let input =
+                  [ Async.Sleep 100
+                    |> Async.bind (fun _ -> dummyAsync 1)
+                    (dummyAsync 2)
+                    (dummyAsync 3) ]
+
+              let expectedOkValue = [ 1; 2; 3 ]
+              let! _actual = AsyncResult.traverse id input
+              Expect.equal orderRun expectedOkValue "Should be run in same order"
+          } ]
+
+[<Tests>]
 let taskTests =
     testList
         "Task tests"
         [ testList
             "fromUnitTask"
-              [ testAsync "should convert from Task to AsyncResult" {
-                    let source = new CancellationTokenSource()
-                    let input: (unit -> Task) = fun () -> Task.Delay(0, source.Token)
+            [ testAsync "should convert from Task to AsyncResult" {
+                let source = new CancellationTokenSource()
+                let input : (unit -> Task) = fun () -> Task.Delay(0, source.Token)
 
-                    let expectedValue = Ok()
+                let expectedValue = Ok()
 
-                    let! actual = AsyncResult.fromUnitTask input
+                let! actual = AsyncResult.fromUnitTask input
 
-                    Expect.equal actual expectedValue "Should be equal"
-                }
-                testAsync "failing Task should result in Error" {
-                    let source = new CancellationTokenSource()
-                    let input = fun () -> Task.Delay(1000, source.Token)
-                    let expectedValue = Error "A task was canceled."
+                Expect.equal actual expectedValue "Should be equal"
+              }
+              testAsync "failing Task should result in Error" {
+                  let source = new CancellationTokenSource()
+                  let input = fun () -> Task.Delay(1000, source.Token)
+                  let expectedValue = Error "A task was canceled."
 
-                    source.Cancel()
+                  source.Cancel()
 
-                    let! actual = AsyncResult.fromUnitTask input
+                  let! actual = AsyncResult.fromUnitTask input
 
-                    Expect.equal actual expectedValue "Should be equal"
-                } ]
+                  Expect.equal actual expectedValue "Should be equal"
+              } ]
           testList
               "fromTask"
               [ testAsync "should convert from Task<string> to AsyncResult" {
-                    let input =
-                        fun () -> Async.singleton "Hello" |> Async.StartAsTask
+                  let input =
+                      fun () -> Async.singleton "Hello" |> Async.StartAsTask
 
-                    let expectedValue = Ok "Hello"
+                  let expectedValue = Ok "Hello"
 
-                    let! actual = AsyncResult.fromTask input
+                  let! actual = AsyncResult.fromTask input
 
-                    Expect.equal actual expectedValue "Should be equal"
+                  Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "fromTask failing Task should result in Error" {
 
@@ -96,4 +149,316 @@ let taskTests =
                     let! actual = AsyncResult.fromTask input
 
                     Expect.equal actual expectedValue "Should be equal"
+                } ] ]
+
+[<Tests>]
+let applyTest =
+    testList
+        "Test apply"
+        [ testAsync "should follow the law of Identity (apply id v = v)" {
+            let v = AsyncResult.fromResult (Ok 42)
+            let f = AsyncResult.fromResult (Ok id)
+
+            let! actual = AsyncResult.apply f v
+            let! expectedValue = v
+
+            Expect.equal actual expectedValue "Should be equal"
+          }
+          testAsync "should follow the law of Homomorphism (apply fA xA = AR.of (f x)" {
+              let x = 42
+              let f = ((+) 10)
+
+              let xA = toAsyncResult x
+              let fA = toAsyncResult f
+
+              let! actual = AsyncResult.apply fA xA
+              let! expectedValue = toAsyncResult (f x)
+
+              Expect.equal actual expectedValue "Should be equal"
+          }
+          testAsync "should follow the law of Composition (xA |> apply fA1 |> apply fA2 = apply fA1 (apply fA2 xA))" {
+              let fA1 = toAsyncResult ((+) 10)
+              let fA2 = toAsyncResult ((-) 2)
+              let xA = toAsyncResult 42
+
+              let! actual =
+                  xA
+                  |> AsyncResult.apply fA2
+                  |> AsyncResult.apply fA1
+
+              let! expectedValue = AsyncResult.apply fA1 (AsyncResult.apply fA2 xA)
+
+              Expect.equal actual expectedValue "Should be equal"
+          } ]
+
+[<Tests>]
+let mapTests =
+    testList
+        "Test mapping functions"
+        [ testList
+            "map"
+            [ testAsync "should change the value in an AsyncResult" {
+                let input = toAsyncResult 3
+
+                let expectedValue = Ok 4
+
+                let! actual = AsyncResult.map ((+) 1) input
+
+                Expect.equal actual expectedValue "Should be equal"
+              }
+              testAsync "should NOT change the value in an Error AsyncResult" {
+                  let input = AsyncResult.fromResult (Error 3)
+
+                  let expectedValue = Error 3
+
+                  let! actual = AsyncResult.map ((+) 1) input
+
+                  Expect.equal actual expectedValue "Should be equal"
+              } ]
+
+          testList
+              "map2"
+              [ testAsync "should map over the value from two AsyncResult" {
+                  let input1 = toAsyncResult 3
+                  let input2 = toAsyncResult 7
+
+                  let expectedValue = Ok 10
+
+                  let! actual = AsyncResult.map2 ((+)) input1 input2
+
+                  Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the first AsyncResult is an error" {
+                    let input1 = AsyncResult.fromResult (Error "Not Ok")
+                    let input2 = toAsyncResult 3
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.map2 ((+)) input1 input2
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the second AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+
+                    let input2 =
+                        AsyncResult.fromResult (Error "Not Ok either")
+
+                    let expectedValue = Error "Not Ok either"
+
+                    let! actual = AsyncResult.map2 ((+)) input1 input2
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should pass arguemnts in order" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 7
+
+                    let expected = Ok(3, 7)
+
+                    let! actual = AsyncResult.map2 (fun a b -> (a, b)) input1 input2
+
+                    Expect.equal actual expected "Should be equal"
+
+                } ]
+
+          testList
+              "map3"
+              [ testAsync "should map over the value from three AsyncResult" {
+                  let input1 = toAsyncResult 3
+                  let input2 = toAsyncResult 7
+                  let input3 = toAsyncResult 4
+
+                  let expectedValue = Ok 14
+
+                  let! actual = AsyncResult.map3 (fun a b c -> a + b + c) input1 input2 input3
+
+                  Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the first AsyncResult is an error" {
+                    let input1 = AsyncResult.fromResult (Error "Not Ok")
+                    let input2 = toAsyncResult 3
+                    let input3 = toAsyncResult 7
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.map3 (fun a b c -> a + b + c) input1 input2 input3
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the second AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+
+                    let input2 =
+                        AsyncResult.fromResult (Error "Not Ok either")
+
+                    let input3 = toAsyncResult 3
+
+                    let expectedValue = Error "Not Ok either"
+
+                    let! actual = AsyncResult.map3 (fun a b c -> a + b + c) input1 input2 input3
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the third AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+
+                    let input2 = toAsyncResult 12
+
+                    let input3 =
+                        AsyncResult.fromResult (Error "Not Ok either")
+
+                    let expectedValue = Error "Not Ok either"
+
+                    let! actual = AsyncResult.map3 (fun a b c -> a + b + c) input1 input2 input3
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should pass arguemnts in order" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 7
+                    let input3 = toAsyncResult 12
+
+                    let expected = Ok(3, 7, 12)
+
+                    let! actual = AsyncResult.map3 (fun a b c -> (a, b, c)) input1 input2 input3
+
+                    Expect.equal actual expected "Should be equal"
+
+                } ]
+
+          testList
+              "map4"
+              [ testAsync "should map over the value from four AsyncResult" {
+                  let input1 = toAsyncResult 3
+                  let input2 = toAsyncResult 7
+                  let input3 = toAsyncResult 4
+                  let input4 = toAsyncResult 6
+
+                  let expectedValue = Ok 20
+
+                  let! actual = AsyncResult.map4 (fun a b c d -> a + b + c + d) input1 input2 input3 input4
+
+                  Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the first AsyncResult is an error" {
+                    let input1 = AsyncResult.fromResult (Error "Not Ok")
+                    let input2 = toAsyncResult 3
+                    let input3 = toAsyncResult 7
+                    let input4 = toAsyncResult 12
+
+                    let expectedValue = Error "Not Ok"
+                    let! actual = AsyncResult.map4 (fun a b c d -> a + b + c + d) input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the second AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+
+                    let input2 =
+                        AsyncResult.fromResult (Error "Not Ok either")
+
+                    let input3 = toAsyncResult 3
+                    let input4 = toAsyncResult 5
+
+                    let expectedValue = Error "Not Ok either"
+
+                    let! actual = AsyncResult.map4 (fun a b c d -> a + b + c + d) input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the third AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+
+                    let input2 = toAsyncResult 12
+
+                    let input3 =
+                        AsyncResult.fromResult (Error "Not Ok either")
+
+                    let input4 = toAsyncResult 5
+
+                    let expectedValue = Error "Not Ok either"
+
+                    let! actual = AsyncResult.map4 (fun a b c d -> a + b + c + d) input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should fail if the fourth AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+
+                    let input2 = toAsyncResult 12
+                    let input3 = toAsyncResult 13
+
+                    let input4 =
+                        AsyncResult.fromResult (Error "Not Ok either")
+
+                    let expectedValue = Error "Not Ok either"
+
+                    let! actual = AsyncResult.map4 (fun a b c d -> a + b + c + d) input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+                testAsync "should pass arguemnts in order" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 7
+                    let input3 = toAsyncResult 12
+                    let input4 = toAsyncResult 0
+
+                    let expected = Ok(3, 7, 12, 0)
+
+                    let! actual = AsyncResult.map4 (fun a b c d -> (a, b, c, d)) input1 input2 input3 input4
+
+                    Expect.equal actual expected "Should be equal"
+
+                } ]
+
+          testList
+              "andMap"
+              [ testAsync "should apply AsyncResult value to AsyncResult function" {
+                  let fA = toAsyncResult ((+) 10)
+                  let xA = toAsyncResult 20
+
+                  let expected = Ok 30
+
+                  let! actual = AsyncResult.andMap xA fA
+
+                  Expect.equal actual expected "Should be equal"
+                }
+                testAsync "should be pipeable" {
+                    let fA = toAsyncResult (fun a b c -> a + b + c)
+                    let xA = toAsyncResult 10
+                    let yA = toAsyncResult 20
+                    let zA = toAsyncResult 30
+
+                    let expected = Ok 60
+
+                    let! actual =
+                        fA
+                        |> AsyncResult.andMap xA
+                        |> AsyncResult.andMap yA
+                        |> AsyncResult.andMap zA
+
+                    Expect.equal actual expected "Should be equal"
+                }
+                testAsync "should fail if there is an Error" {
+                    let fA = toAsyncResult (fun a b c -> a + b + c)
+                    let xA = toAsyncResult 10
+
+                    let yA =
+                        AsyncResult.fromResult (Error "Oh no an error")
+
+                    let zA = toAsyncResult 30
+
+                    let expected = Error "Oh no an error"
+
+                    let! actual =
+                        fA
+                        |> AsyncResult.andMap xA
+                        |> AsyncResult.andMap yA
+                        |> AsyncResult.andMap zA
+
+                    Expect.equal actual expected "Should be equal"
                 } ] ]

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -608,4 +608,91 @@ let bindTests =
 
                     Expect.equal actual expected "Should be equal"
 
+                } ]
+
+          testList
+              "bind4"
+              [ testAsync "should map over the value from four AsyncResult" {
+                  let input1 = toAsyncResult 3
+                  let input2 = toAsyncResult 7
+                  let input3 = toAsyncResult 32
+                  let input4 = toAsyncResult 10
+                  let f a b c d = toAsyncResult (a + b + c + d)
+
+                  let expectedValue = Ok 52
+
+                  let! actual = AsyncResult.bind4 f input1 input2 input3 input4
+
+                  Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the first AsyncResult is an error" {
+                    let input1 = AsyncResult.fromResult (Error "Not Ok")
+                    let input2 = toAsyncResult 3
+                    let input3 = toAsyncResult 32
+                    let input4 = toAsyncResult 10
+                    let f a b c d = toAsyncResult (a + b + c + d)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind4 f input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the second AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+                    let input2 = AsyncResult.fromResult (Error "Not Ok")
+                    let input3 = toAsyncResult 4
+                    let input4 = toAsyncResult 10
+                    let f a b c d = toAsyncResult (a + b + c + d)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind4 f input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the third AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 4
+                    let input3 = AsyncResult.fromResult (Error "Not Ok")
+                    let input4 = toAsyncResult 10
+                    let f a b c d = toAsyncResult (a + b + c + d)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind4 f input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should fail if the fourth AsyncResult is an error" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 4
+                    let input3 = toAsyncResult 10
+                    let input4 = AsyncResult.fromResult (Error "Not Ok")
+                    let f a b c d = toAsyncResult (a + b + c + d)
+
+                    let expectedValue = Error "Not Ok"
+
+                    let! actual = AsyncResult.bind4 f input1 input2 input3 input4
+
+                    Expect.equal actual expectedValue "Should be equal"
+                }
+
+                testAsync "should pass arguments in order" {
+                    let input1 = toAsyncResult 3
+                    let input2 = toAsyncResult 7
+                    let input3 = toAsyncResult 99
+                    let input4 = toAsyncResult 15
+
+                    let expected = Ok(3, 7, 99, 15)
+
+                    let! actual =
+                        AsyncResult.bind4 (fun a b c d -> toAsyncResult (a, b, c, d)) input1 input2 input3 input4
+
+                    Expect.equal actual expected "Should be equal"
+
                 } ] ]

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -5,7 +5,56 @@ open System.Threading.Tasks
 open Insurello.AsyncExtra
 open Expecto
 
-let toAsyncResult<'x> : 'x -> AsyncResult<'x, string> = Ok >> AsyncResult.fromResult
+[<Tests>]
+let creationTests =
+    testList
+        "Test creating new AsyncResult"
+        [ testList
+              "singleton"
+              [ testAsync "should create an Ok AsyncResult given a string" {
+                  let value = "test"
+
+                  let! actual = AsyncResult.singleton value
+                  let expected = Ok value
+
+                  Expect.equal actual expected "should equal"
+                }
+
+                testAsync "should create an Ok AsyncResult given an int" {
+                    let value = 4
+
+                    let! actual = AsyncResult.singleton value
+                    let expected = Ok value
+
+                    Expect.equal actual expected "should equal"
+                }
+
+                testAsync "should create an Ok AsyncResult given a bool" {
+                    let value = true
+
+                    let! actual = AsyncResult.singleton value
+                    let expected = Ok value
+
+                    Expect.equal actual expected "should equal"
+                }
+
+                testAsync "should nest Ok in a Ok AsyncResult" {
+                    let value = Ok 1
+
+                    let! actual = AsyncResult.singleton value
+                    let expected = Ok value
+
+                    Expect.equal actual expected "should equal"
+                }
+
+                testAsync "should nest Error in a Ok AsyncResult" {
+                    let value = Error "This is in an Ok"
+
+                    let! actual = AsyncResult.singleton value
+                    let expected = Ok value
+
+                    Expect.equal actual expected "should equal"
+                } ] ]
 
 [<Tests>]
 let sequenceTests =
@@ -15,9 +64,9 @@ let sequenceTests =
             let expected = Ok [ 1; 2; 3 ]
 
             let input =
-                [ (toAsyncResult 1)
-                  (toAsyncResult 2)
-                  (toAsyncResult 3) ]
+                [ (AsyncResult.singleton 1)
+                  (AsyncResult.singleton 2)
+                  (AsyncResult.singleton 3) ]
 
             let! actual = AsyncResult.sequence input
             Expect.equal actual expected "should equal"
@@ -52,9 +101,9 @@ let traverseTests =
             let expected = Ok [ 1; 2; 3 ]
 
             let input =
-                [ (toAsyncResult 1)
-                  (toAsyncResult 2)
-                  (toAsyncResult 3) ]
+                [ (AsyncResult.singleton 1)
+                  (AsyncResult.singleton 2)
+                  (AsyncResult.singleton 3) ]
 
             let! actual = AsyncResult.traverse id input
             Expect.equal actual expected "should equal"
@@ -65,9 +114,9 @@ let traverseTests =
               let expected = Ok [ 11; 12; 13 ]
 
               let input =
-                  [ (toAsyncResult 1)
-                    (toAsyncResult 2)
-                    (toAsyncResult 3) ]
+                  [ (AsyncResult.singleton 1)
+                    (AsyncResult.singleton 2)
+                    (AsyncResult.singleton 3) ]
 
               let! actual = AsyncResult.traverse transformer input
               Expect.equal actual expected "should equal"
@@ -166,18 +215,18 @@ let applyTest =
               let x = 42
               let f = ((+) 10)
 
-              let xA = toAsyncResult x
-              let fA = toAsyncResult f
+              let xA = AsyncResult.singleton x
+              let fA = AsyncResult.singleton f
 
               let! actual = AsyncResult.apply fA xA
-              let! expectedValue = toAsyncResult (f x)
+              let! expectedValue = AsyncResult.singleton (f x)
 
               Expect.equal actual expectedValue "Should be equal"
           }
           testAsync "should follow the law of Composition (xA |> apply fA1 |> apply fA2 = apply fA1 (apply fA2 xA))" {
-              let fA1 = toAsyncResult ((+) 10)
-              let fA2 = toAsyncResult ((-) 2)
-              let xA = toAsyncResult 42
+              let fA1 = AsyncResult.singleton ((+) 10)
+              let fA2 = AsyncResult.singleton ((-) 2)
+              let xA = AsyncResult.singleton 42
 
               let! actual =
                   xA
@@ -196,7 +245,7 @@ let mapTests =
         [ testList
             "map"
             [ testAsync "should change the value in an AsyncResult" {
-                let input = toAsyncResult 3
+                let input = AsyncResult.singleton 3
 
                 let expectedValue = Ok 4
 
@@ -217,8 +266,8 @@ let mapTests =
           testList
               "map2"
               [ testAsync "should map over the value from two AsyncResult" {
-                  let input1 = toAsyncResult 3
-                  let input2 = toAsyncResult 7
+                  let input1 = AsyncResult.singleton 3
+                  let input2 = AsyncResult.singleton 7
 
                   let expectedValue = Ok 10
 
@@ -229,7 +278,7 @@ let mapTests =
 
                 testAsync "should fail if the first AsyncResult is an error" {
                     let input1 = AsyncResult.fromResult (Error "Not Ok")
-                    let input2 = toAsyncResult 3
+                    let input2 = AsyncResult.singleton 3
 
                     let expectedValue = Error "Not Ok"
 
@@ -239,7 +288,7 @@ let mapTests =
                 }
 
                 testAsync "should fail if the second AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
 
                     let input2 =
                         AsyncResult.fromResult (Error "Not Ok either")
@@ -252,8 +301,8 @@ let mapTests =
                 }
 
                 testAsync "should pass arguments in order" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
 
                     let expected = Ok(3, 7)
 
@@ -266,9 +315,9 @@ let mapTests =
           testList
               "map3"
               [ testAsync "should map over the value from three AsyncResult" {
-                  let input1 = toAsyncResult 3
-                  let input2 = toAsyncResult 7
-                  let input3 = toAsyncResult 4
+                  let input1 = AsyncResult.singleton 3
+                  let input2 = AsyncResult.singleton 7
+                  let input3 = AsyncResult.singleton 4
 
                   let expectedValue = Ok 14
 
@@ -278,8 +327,8 @@ let mapTests =
                 }
                 testAsync "should fail if the first AsyncResult is an error" {
                     let input1 = AsyncResult.fromResult (Error "Not Ok")
-                    let input2 = toAsyncResult 3
-                    let input3 = toAsyncResult 7
+                    let input2 = AsyncResult.singleton 3
+                    let input3 = AsyncResult.singleton 7
 
                     let expectedValue = Error "Not Ok"
 
@@ -288,12 +337,12 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should fail if the second AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
 
                     let input2 =
                         AsyncResult.fromResult (Error "Not Ok either")
 
-                    let input3 = toAsyncResult 3
+                    let input3 = AsyncResult.singleton 3
 
                     let expectedValue = Error "Not Ok either"
 
@@ -302,9 +351,9 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should fail if the third AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
 
-                    let input2 = toAsyncResult 12
+                    let input2 = AsyncResult.singleton 12
 
                     let input3 =
                         AsyncResult.fromResult (Error "Not Ok either")
@@ -316,9 +365,9 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should pass arguments in order" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
-                    let input3 = toAsyncResult 12
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
+                    let input3 = AsyncResult.singleton 12
 
                     let expected = Ok(3, 7, 12)
 
@@ -331,10 +380,10 @@ let mapTests =
           testList
               "map4"
               [ testAsync "should map over the value from four AsyncResult" {
-                  let input1 = toAsyncResult 3
-                  let input2 = toAsyncResult 7
-                  let input3 = toAsyncResult 4
-                  let input4 = toAsyncResult 6
+                  let input1 = AsyncResult.singleton 3
+                  let input2 = AsyncResult.singleton 7
+                  let input3 = AsyncResult.singleton 4
+                  let input4 = AsyncResult.singleton 6
 
                   let expectedValue = Ok 20
 
@@ -344,9 +393,9 @@ let mapTests =
                 }
                 testAsync "should fail if the first AsyncResult is an error" {
                     let input1 = AsyncResult.fromResult (Error "Not Ok")
-                    let input2 = toAsyncResult 3
-                    let input3 = toAsyncResult 7
-                    let input4 = toAsyncResult 12
+                    let input2 = AsyncResult.singleton 3
+                    let input3 = AsyncResult.singleton 7
+                    let input4 = AsyncResult.singleton 12
 
                     let expectedValue = Error "Not Ok"
                     let! actual = AsyncResult.map4 (fun a b c d -> a + b + c + d) input1 input2 input3 input4
@@ -354,13 +403,13 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should fail if the second AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
 
                     let input2 =
                         AsyncResult.fromResult (Error "Not Ok either")
 
-                    let input3 = toAsyncResult 3
-                    let input4 = toAsyncResult 5
+                    let input3 = AsyncResult.singleton 3
+                    let input4 = AsyncResult.singleton 5
 
                     let expectedValue = Error "Not Ok either"
 
@@ -369,14 +418,14 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should fail if the third AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
 
-                    let input2 = toAsyncResult 12
+                    let input2 = AsyncResult.singleton 12
 
                     let input3 =
                         AsyncResult.fromResult (Error "Not Ok either")
 
-                    let input4 = toAsyncResult 5
+                    let input4 = AsyncResult.singleton 5
 
                     let expectedValue = Error "Not Ok either"
 
@@ -385,10 +434,10 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should fail if the fourth AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
 
-                    let input2 = toAsyncResult 12
-                    let input3 = toAsyncResult 13
+                    let input2 = AsyncResult.singleton 12
+                    let input3 = AsyncResult.singleton 13
 
                     let input4 =
                         AsyncResult.fromResult (Error "Not Ok either")
@@ -400,10 +449,10 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
                 testAsync "should pass arguments in order" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
-                    let input3 = toAsyncResult 12
-                    let input4 = toAsyncResult 0
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
+                    let input3 = AsyncResult.singleton 12
+                    let input4 = AsyncResult.singleton 0
 
                     let expected = Ok(3, 7, 12, 0)
 
@@ -416,8 +465,8 @@ let mapTests =
           testList
               "andMap"
               [ testAsync "should apply AsyncResult value to AsyncResult function" {
-                  let fA = toAsyncResult ((+) 10)
-                  let xA = toAsyncResult 20
+                  let fA = AsyncResult.singleton ((+) 10)
+                  let xA = AsyncResult.singleton 20
 
                   let expected = Ok 30
 
@@ -426,10 +475,12 @@ let mapTests =
                   Expect.equal actual expected "Should be equal"
                 }
                 testAsync "should be pipeable" {
-                    let fA = toAsyncResult (fun a b c -> a + b + c)
-                    let xA = toAsyncResult 10
-                    let yA = toAsyncResult 20
-                    let zA = toAsyncResult 30
+                    let fA =
+                        AsyncResult.singleton (fun a b c -> a + b + c)
+
+                    let xA = AsyncResult.singleton 10
+                    let yA = AsyncResult.singleton 20
+                    let zA = AsyncResult.singleton 30
 
                     let expected = Ok 60
 
@@ -442,13 +493,15 @@ let mapTests =
                     Expect.equal actual expected "Should be equal"
                 }
                 testAsync "should fail if there is an Error" {
-                    let fA = toAsyncResult (fun a b c -> a + b + c)
-                    let xA = toAsyncResult 10
+                    let fA =
+                        AsyncResult.singleton (fun a b c -> a + b + c)
+
+                    let xA = AsyncResult.singleton 10
 
                     let yA =
                         AsyncResult.fromResult (Error "Oh no an error")
 
-                    let zA = toAsyncResult 30
+                    let zA = AsyncResult.singleton 30
 
                     let expected = Error "Oh no an error"
 
@@ -468,9 +521,9 @@ let bindTests =
         [ testList
             "bind"
             [ testAsync "should change the value in an AsyncResult" {
-                let input = toAsyncResult 3
+                let input = AsyncResult.singleton 3
 
-                let f = ((+) 1 >> toAsyncResult)
+                let f = ((+) 1 >> AsyncResult.singleton)
 
                 let expectedValue = Ok 4
 
@@ -494,9 +547,9 @@ let bindTests =
           testList
               "bind2"
               [ testAsync "should map over the value from two AsyncResult" {
-                  let input1 = toAsyncResult 3
-                  let input2 = toAsyncResult 7
-                  let f a b = toAsyncResult (a + b)
+                  let input1 = AsyncResult.singleton 3
+                  let input2 = AsyncResult.singleton 7
+                  let f a b = AsyncResult.singleton (a + b)
 
                   let expectedValue = Ok 10
 
@@ -507,8 +560,8 @@ let bindTests =
 
                 testAsync "should fail if the first AsyncResult is an error" {
                     let input1 = AsyncResult.fromResult (Error "Not Ok")
-                    let input2 = toAsyncResult 3
-                    let f a b = toAsyncResult (a + b)
+                    let input2 = AsyncResult.singleton 3
+                    let f a b = AsyncResult.singleton (a + b)
 
                     let expectedValue = Error "Not Ok"
 
@@ -518,9 +571,9 @@ let bindTests =
                 }
 
                 testAsync "should fail if the second AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
                     let input2 = AsyncResult.fromResult (Error "Not Ok")
-                    let f a b = toAsyncResult (a + b)
+                    let f a b = AsyncResult.singleton (a + b)
 
                     let expectedValue = Error "Not Ok"
 
@@ -530,12 +583,12 @@ let bindTests =
                 }
 
                 testAsync "should pass arguments in order" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
 
                     let expected = Ok(3, 7)
 
-                    let! actual = AsyncResult.bind2 (fun a b -> toAsyncResult (a, b)) input1 input2
+                    let! actual = AsyncResult.bind2 (fun a b -> AsyncResult.singleton (a, b)) input1 input2
 
                     Expect.equal actual expected "Should be equal"
 
@@ -544,10 +597,10 @@ let bindTests =
           testList
               "bind3"
               [ testAsync "should map over the value from three AsyncResult" {
-                  let input1 = toAsyncResult 3
-                  let input2 = toAsyncResult 7
-                  let input3 = toAsyncResult 32
-                  let f a b c = toAsyncResult (a + b + c)
+                  let input1 = AsyncResult.singleton 3
+                  let input2 = AsyncResult.singleton 7
+                  let input3 = AsyncResult.singleton 32
+                  let f a b c = AsyncResult.singleton (a + b + c)
 
                   let expectedValue = Ok 42
 
@@ -558,9 +611,9 @@ let bindTests =
 
                 testAsync "should fail if the first AsyncResult is an error" {
                     let input1 = AsyncResult.fromResult (Error "Not Ok")
-                    let input2 = toAsyncResult 3
-                    let input3 = toAsyncResult 32
-                    let f a b c = toAsyncResult (a + b + c)
+                    let input2 = AsyncResult.singleton 3
+                    let input3 = AsyncResult.singleton 32
+                    let f a b c = AsyncResult.singleton (a + b + c)
 
                     let expectedValue = Error "Not Ok"
 
@@ -570,10 +623,10 @@ let bindTests =
                 }
 
                 testAsync "should fail if the second AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
                     let input2 = AsyncResult.fromResult (Error "Not Ok")
-                    let input3 = toAsyncResult 4
-                    let f a b c = toAsyncResult (a + b + c)
+                    let input3 = AsyncResult.singleton 4
+                    let f a b c = AsyncResult.singleton (a + b + c)
 
                     let expectedValue = Error "Not Ok"
 
@@ -583,10 +636,10 @@ let bindTests =
                 }
 
                 testAsync "should fail if the third AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 4
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 4
                     let input3 = AsyncResult.fromResult (Error "Not Ok")
-                    let f a b c = toAsyncResult (a + b + c)
+                    let f a b c = AsyncResult.singleton (a + b + c)
 
                     let expectedValue = Error "Not Ok"
 
@@ -596,13 +649,13 @@ let bindTests =
                 }
 
                 testAsync "should pass arguments in order" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
-                    let input3 = toAsyncResult 99
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
+                    let input3 = AsyncResult.singleton 99
 
                     let expected = Ok(3, 7, 99)
 
-                    let! actual = AsyncResult.bind3 (fun a b c -> toAsyncResult (a, b, c)) input1 input2 input3
+                    let! actual = AsyncResult.bind3 (fun a b c -> AsyncResult.singleton (a, b, c)) input1 input2 input3
 
                     Expect.equal actual expected "Should be equal"
 
@@ -611,11 +664,11 @@ let bindTests =
           testList
               "bind4"
               [ testAsync "should map over the value from four AsyncResult" {
-                  let input1 = toAsyncResult 3
-                  let input2 = toAsyncResult 7
-                  let input3 = toAsyncResult 32
-                  let input4 = toAsyncResult 10
-                  let f a b c d = toAsyncResult (a + b + c + d)
+                  let input1 = AsyncResult.singleton 3
+                  let input2 = AsyncResult.singleton 7
+                  let input3 = AsyncResult.singleton 32
+                  let input4 = AsyncResult.singleton 10
+                  let f a b c d = AsyncResult.singleton (a + b + c + d)
 
                   let expectedValue = Ok 52
 
@@ -626,10 +679,10 @@ let bindTests =
 
                 testAsync "should fail if the first AsyncResult is an error" {
                     let input1 = AsyncResult.fromResult (Error "Not Ok")
-                    let input2 = toAsyncResult 3
-                    let input3 = toAsyncResult 32
-                    let input4 = toAsyncResult 10
-                    let f a b c d = toAsyncResult (a + b + c + d)
+                    let input2 = AsyncResult.singleton 3
+                    let input3 = AsyncResult.singleton 32
+                    let input4 = AsyncResult.singleton 10
+                    let f a b c d = AsyncResult.singleton (a + b + c + d)
 
                     let expectedValue = Error "Not Ok"
 
@@ -639,11 +692,11 @@ let bindTests =
                 }
 
                 testAsync "should fail if the second AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
+                    let input1 = AsyncResult.singleton 3
                     let input2 = AsyncResult.fromResult (Error "Not Ok")
-                    let input3 = toAsyncResult 4
-                    let input4 = toAsyncResult 10
-                    let f a b c d = toAsyncResult (a + b + c + d)
+                    let input3 = AsyncResult.singleton 4
+                    let input4 = AsyncResult.singleton 10
+                    let f a b c d = AsyncResult.singleton (a + b + c + d)
 
                     let expectedValue = Error "Not Ok"
 
@@ -653,11 +706,11 @@ let bindTests =
                 }
 
                 testAsync "should fail if the third AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 4
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 4
                     let input3 = AsyncResult.fromResult (Error "Not Ok")
-                    let input4 = toAsyncResult 10
-                    let f a b c d = toAsyncResult (a + b + c + d)
+                    let input4 = AsyncResult.singleton 10
+                    let f a b c d = AsyncResult.singleton (a + b + c + d)
 
                     let expectedValue = Error "Not Ok"
 
@@ -667,11 +720,11 @@ let bindTests =
                 }
 
                 testAsync "should fail if the fourth AsyncResult is an error" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 4
-                    let input3 = toAsyncResult 10
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 4
+                    let input3 = AsyncResult.singleton 10
                     let input4 = AsyncResult.fromResult (Error "Not Ok")
-                    let f a b c d = toAsyncResult (a + b + c + d)
+                    let f a b c d = AsyncResult.singleton (a + b + c + d)
 
                     let expectedValue = Error "Not Ok"
 
@@ -681,15 +734,20 @@ let bindTests =
                 }
 
                 testAsync "should pass arguments in order" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
-                    let input3 = toAsyncResult 99
-                    let input4 = toAsyncResult 15
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
+                    let input3 = AsyncResult.singleton 99
+                    let input4 = AsyncResult.singleton 15
 
                     let expected = Ok(3, 7, 99, 15)
 
                     let! actual =
-                        AsyncResult.bind4 (fun a b c d -> toAsyncResult (a, b, c, d)) input1 input2 input3 input4
+                        AsyncResult.bind4
+                            (fun a b c d -> AsyncResult.singleton (a, b, c, d))
+                            input1
+                            input2
+                            input3
+                            input4
 
                     Expect.equal actual expected "Should be equal"
 
@@ -698,12 +756,14 @@ let bindTests =
           testList
               "bind5"
               [ testAsync "should map over the value from five AsyncResult" {
-                    let input1 = toAsyncResult 3
-                    let input2 = toAsyncResult 7
-                    let input3 = toAsyncResult 32
-                    let input4 = toAsyncResult 10
-                    let input5 = toAsyncResult 115
-                    let f a b c d e = toAsyncResult (a + b + c + d + e)
+                    let input1 = AsyncResult.singleton 3
+                    let input2 = AsyncResult.singleton 7
+                    let input3 = AsyncResult.singleton 32
+                    let input4 = AsyncResult.singleton 10
+                    let input5 = AsyncResult.singleton 115
+
+                    let f a b c d e =
+                        AsyncResult.singleton (a + b + c + d + e)
 
                     let expectedValue = Ok 167
 

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -253,7 +253,7 @@ let mapTests =
                     Expect.equal actual expectedValue "Should be equal"
                 }
 
-                testAsync "should pass arguemnts in order" {
+                testAsync "should pass arguments in order" {
                     let input1 = toAsyncResult 3
                     let input2 = toAsyncResult 7
 
@@ -317,7 +317,7 @@ let mapTests =
 
                     Expect.equal actual expectedValue "Should be equal"
                 }
-                testAsync "should pass arguemnts in order" {
+                testAsync "should pass arguments in order" {
                     let input1 = toAsyncResult 3
                     let input2 = toAsyncResult 7
                     let input3 = toAsyncResult 12
@@ -401,7 +401,7 @@ let mapTests =
 
                     Expect.equal actual expectedValue "Should be equal"
                 }
-                testAsync "should pass arguemnts in order" {
+                testAsync "should pass arguments in order" {
                     let input1 = toAsyncResult 3
                     let input2 = toAsyncResult 7
                     let input3 = toAsyncResult 12

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -12,14 +12,12 @@ let sequenceTests =
     testList
         "Sequence tests"
         [ testAsync "should return values in same order as given tasks" {
-            let dummyAsync : int -> AsyncResult<int, string> = Ok >> AsyncResult.fromResult
-
             let expected = Ok [ 1; 2; 3 ]
 
             let input =
-                [ (dummyAsync 1)
-                  (dummyAsync 2)
-                  (dummyAsync 3) ]
+                [ (toAsyncResult 1)
+                  (toAsyncResult 2)
+                  (toAsyncResult 3) ]
 
             let! actual = AsyncResult.sequence input
             Expect.equal actual expected "should equal"

--- a/src/Insurello.AsyncExtra.Tests/Insurello.AsyncExtra.Tests.fsproj
+++ b/src/Insurello.AsyncExtra.Tests/Insurello.AsyncExtra.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -110,3 +110,6 @@ module AsyncResult =
 
     let bind4 : ('a -> 'b -> 'c -> 'd -> AsyncResult<'e, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> =
         fun f a1 a2 a3 a4 -> map4 f a1 a2 a3 a4 |> bind id
+
+    let bind5 : ('a -> 'b -> 'c -> 'd -> 'e -> AsyncResult<'f, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err> =
+        fun f a1 a2 a3 a4 a5 -> map5 f a1 a2 a3 a4 a5 |> bind id

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -101,3 +101,6 @@ module AsyncResult =
 
     let andMap : AsyncResult<'a, 'err> -> AsyncResult<('a -> 'b), 'err> -> AsyncResult<'b, 'err> =
         fun a1 a2 -> apply a2 a1
+
+    let bind2 : ('a -> 'b -> AsyncResult<'c, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> =
+        fun f a1 a2 -> map2 f a1 a2 |> bind id

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -14,6 +14,8 @@ type AsyncResult<'x, 'err> = Async<Result<'x, 'err>>
 module AsyncResult =
     let fromResult : Result<'x, 'err> -> AsyncResult<'x, 'err> = Async.singleton
 
+    let singleton : 'x -> AsyncResult<'x, 'err> = fun x -> fromResult (Ok x)
+
     let fromOption : 'err -> Option<'x> -> AsyncResult<'x, 'err> =
         fun err option ->
             match option with
@@ -80,7 +82,7 @@ module AsyncResult =
             let mapConcat headR tailR =
                 apply (map (transformer >> cons) headR) tailR
 
-            List.foldBack mapConcat list (fromResult (Ok []))
+            List.foldBack mapConcat list (singleton [])
 
     let sequence : AsyncResult<'x, 'error> list -> AsyncResult<'x list, 'error> = fun list -> traverse id list
 
@@ -113,3 +115,6 @@ module AsyncResult =
 
     let bind5 : ('a -> 'b -> 'c -> 'd -> 'e -> AsyncResult<'f, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err> =
         fun f a1 a2 a3 a4 a5 -> map5 f a1 a2 a3 a4 a5 |> bind id
+
+    let andBind : AsyncResult<'a, 'err> -> AsyncResult<('a -> AsyncResult<'b, 'err>), 'err> -> AsyncResult<'b, 'err> =
+        fun a1 a2 -> andMap a1 a2 |> bind id

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -104,3 +104,6 @@ module AsyncResult =
 
     let bind2 : ('a -> 'b -> AsyncResult<'c, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> =
         fun f a1 a2 -> map2 f a1 a2 |> bind id
+
+    let bind3 : ('a -> 'b -> 'c -> AsyncResult<'d, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> =
+        fun f a1 a2 a3 -> map3 f a1 a2 a3 |> bind id

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -2,68 +2,102 @@ namespace Insurello.AsyncExtra
 
 [<RequireQualifiedAccessAttribute>]
 module Async =
-    let singleton: 'value -> Async<'value> = async.Return
+    let singleton : 'value -> Async<'value> = async.Return
 
-    let bind: ('x -> Async<'y>) -> Async<'x> -> Async<'y> = fun f x -> async.Bind(x, f)
+    let bind : ('x -> Async<'y>) -> Async<'x> -> Async<'y> = fun f x -> async.Bind(x, f)
 
-    let map: ('x -> 'y) -> Async<'x> -> Async<'y> = fun f x -> bind (f >> singleton) x
+    let map : ('x -> 'y) -> Async<'x> -> Async<'y> = fun f x -> bind (f >> singleton) x
 
 type AsyncResult<'x, 'err> = Async<Result<'x, 'err>>
 
 [<RequireQualifiedAccessAttribute>]
 module AsyncResult =
-    let fromResult: Result<'x, 'err> -> AsyncResult<'x, 'err> = Async.singleton
+    let fromResult : Result<'x, 'err> -> AsyncResult<'x, 'err> = Async.singleton
 
-    let fromOption: 'err -> Option<'x> -> AsyncResult<'x, 'err> =
+    let fromOption : 'err -> Option<'x> -> AsyncResult<'x, 'err> =
         fun err option ->
             match option with
             | Some x -> Ok x
             | None -> Error err
             |> fromResult
 
-    let fromTask: (unit -> System.Threading.Tasks.Task<'x>) -> AsyncResult<'x, string> =
+    let fromTask : (unit -> System.Threading.Tasks.Task<'x>) -> AsyncResult<'x, string> =
         fun lazyTask ->
             async.Delay(lazyTask >> Async.AwaitTask)
             |> Async.Catch
-            |> Async.map (function
+            |> Async.map
+                (function
                 | Choice1Of2 response -> Ok response
                 | Choice2Of2 exn -> Error exn.Message)
 
-    let fromUnitTask: (unit -> System.Threading.Tasks.Task) -> AsyncResult<unit, string> =
+    let fromUnitTask : (unit -> System.Threading.Tasks.Task) -> AsyncResult<unit, string> =
         fun lazyTask ->
             async.Delay(lazyTask >> Async.AwaitTask)
             |> Async.Catch
-            |> Async.map (function
+            |> Async.map
+                (function
                 | Choice1Of2 response -> Ok response
                 | Choice2Of2 exn -> Error exn.Message)
 
-    let map: ('x -> 'y) -> AsyncResult<'x, 'err> -> AsyncResult<'y, 'err> =
+    let map : ('x -> 'y) -> AsyncResult<'x, 'err> -> AsyncResult<'y, 'err> =
         fun f asyncResultX -> Async.map (Result.map f) asyncResultX
 
-    let mapError: ('errX -> 'errY) -> AsyncResult<'x, 'errX> -> AsyncResult<'x, 'errY> =
+    let mapError : ('errX -> 'errY) -> AsyncResult<'x, 'errX> -> AsyncResult<'x, 'errY> =
         fun f asyncResultX -> Async.map (Result.mapError f) asyncResultX
 
-    let bind: ('x -> AsyncResult<'y, 'err>) -> AsyncResult<'x, 'err> -> AsyncResult<'y, 'err> =
+    let bind : ('x -> AsyncResult<'y, 'err>) -> AsyncResult<'x, 'err> -> AsyncResult<'y, 'err> =
         fun successMapper ->
-            Async.bind (function
+            Async.bind
+                (function
                 | Ok x -> successMapper x
                 | Error err -> Async.singleton (Error err))
 
-    let bindError: ('errT -> AsyncResult<'x, 'errU>) -> AsyncResult<'x, 'errT> -> AsyncResult<'x, 'errU> =
+    let bindError : ('errT -> AsyncResult<'x, 'errU>) -> AsyncResult<'x, 'errT> -> AsyncResult<'x, 'errU> =
         fun errorMapper ->
-            Async.bind (function
+            Async.bind
+                (function
                 | Ok x -> Async.singleton (Ok x)
                 | Error err -> errorMapper err)
 
-    let sequence: AsyncResult<'x, 'error> list -> AsyncResult<'x list, 'error> =
-        let folder: AsyncResult<'x list, 'error> -> AsyncResult<'x, 'error> -> AsyncResult<'x list, 'error> =
-            fun acc nextAsyncResult ->
-                acc
-                |> bind (fun okValues ->
-                    nextAsyncResult
-                    |> map (fun nextOkValue -> nextOkValue :: okValues))
+    let apply : AsyncResult<('a -> 'b), 'err> -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> =
+        fun fA xA ->
+            async {
+                let! fR = fA
+                let! xR = xA
 
-        fun asyncs ->
-            asyncs
-            |> List.fold folder (fromResult (Ok []))
-            |> map List.rev
+                return
+                    match fR, xR with
+                    | Ok f, Ok x -> Ok(f x)
+                    | Error err1, Ok _ -> Error err1
+                    | Ok _, Error err2 -> Error err2
+                    | Error err1, Error _ -> Error err1
+            }
+
+    let traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err> =
+        fun transformer list ->
+            let cons head tail = head :: tail
+
+            let mapConcat headR tailR =
+                apply (map (transformer >> cons) headR) tailR
+
+            List.foldBack mapConcat list (fromResult (Ok []))
+
+    let sequence : AsyncResult<'x, 'error> list -> AsyncResult<'x list, 'error> = fun list -> traverse id list
+
+    let private (<!>) = map
+    let private (<*>) = apply
+
+    let map2 : ('a -> 'b -> 'c) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> =
+        fun f a1 a2 -> f <!> a1 <*> a2
+
+    let map3 : ('a -> 'b -> 'c -> 'd) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> =
+        fun f a1 a2 a3 -> f <!> a1 <*> a2 <*> a3
+
+    let map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> =
+        fun f a1 a2 a3 a4 -> f <!> a1 <*> a2 <*> a3 <*> a4
+
+    let map5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err> =
+        fun f a1 a2 a3 a4 a5 -> f <!> a1 <*> a2 <*> a3 <*> a4 <*> a5
+
+    let andMap : AsyncResult<'a, 'err> -> AsyncResult<('a -> 'b), 'err> -> AsyncResult<'b, 'err> =
+        fun a1 a2 -> apply a2 a1

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -107,3 +107,6 @@ module AsyncResult =
 
     let bind3 : ('a -> 'b -> 'c -> AsyncResult<'d, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> =
         fun f a1 a2 a3 -> map3 f a1 a2 a3 |> bind id
+
+    let bind4 : ('a -> 'b -> 'c -> 'd -> AsyncResult<'e, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> =
+        fun f a1 a2 a3 a4 -> map4 f a1 a2 a3 a4 |> bind id

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -115,6 +115,3 @@ module AsyncResult =
 
     let bind5 : ('a -> 'b -> 'c -> 'd -> 'e -> AsyncResult<'f, 'err>) -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err> -> AsyncResult<'c, 'err> -> AsyncResult<'d, 'err> -> AsyncResult<'e, 'err> -> AsyncResult<'f, 'err> =
         fun f a1 a2 a3 a4 a5 -> map5 f a1 a2 a3 a4 a5 |> bind id
-
-    let andBind : AsyncResult<'a, 'err> -> AsyncResult<('a -> AsyncResult<'b, 'err>), 'err> -> AsyncResult<'b, 'err> =
-        fun a1 a2 -> andMap a1 a2 |> bind id

--- a/src/Insurello.AsyncExtra/Insurello.AsyncExtra.fsproj
+++ b/src/Insurello.AsyncExtra/Insurello.AsyncExtra.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <PackageId>Insurello.AsyncExtra</PackageId>
     <Authors>Insurello</Authors>
     <Company>Insurello</Company>


### PR DESCRIPTION
I've taken the liberty to add some commonly used helper functions that I often miss when using AsyncExtra.

I've also updated the package to use dotnet 5.0.

### New functions
#### Singleton
```fsharp
'a -> AsyncResult<'a, 'err>
```
If you know that it should be an Ok AsyncResult you can use `AsyncResult.singleton x` instead of `AsyncResult.fromResult (Ok x)`.

#### Traverse
```fsharp
('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err>
```
Similar to `sequence` but it allows you to transform the values in the list. This also allowed me to refactor sequence to and instead use `traverse id list`.

Basically, it let's you refactor this common use case:
```fsharp
list
|> List.map fnToAR
|> AsyncResult.sequence
```
into this:
```fsharp
AsyncResult.traverse fnToAR list
```


#### map2 - map5 & andMap
These are more commonly known as `liftX` in Javascript and F# but since Elm uses `mapX` I thought it was better since we usually follow Elm's naming convention. It takes a transformer function which takes `X` number of arguments.

#### bind2 - bind5
The same as `mapX` but the transformer function is returning an AsyncResult. 

#### Apply
```fsharp
AsyncResult<('a -> 'b), 'err> -> AsyncResult<'a, 'err> -> AsyncResult<'b, 'err>
```
Convenient helper function that is used to implement all of the previously mentioned functions. It's similar to `andMap` but takes the arguments in a reversed order. It also makes `AsyncResult` into an `Applicative`.
