### PR TITLE
Optimize traverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Solves the same problem as [`bind2`](#bind2) but for five arguments.
 sequence : List<AsyncResult<'a, 'error>> -> AsyncResult<'a list, 'error>
 ```
 
-From time to time you will find yourself having a list of `AsyncResult` (`List<AsyncResult<'a, 'err>`) but you would rather have an `AsyncResult` with a list of values (`AsyncResult<'a list, 'error>`). In those cases `sequence` can help you.
+From time to time you will find yourself having a list of `AsyncResult` (`List<AsyncResult<'a, 'err>`) but you would rather have an `AsyncResult` with a list of values (`AsyncResult<'a list, 'error>`). In those cases `sequence` can help you. `sequence` will make an early return if it reaches an `Error`.
 
 ```fsharp
 fetchUser : int -> AsyncResult<User, string>
@@ -315,7 +315,7 @@ userIds // [1; 2; 3]
 traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err>
 ```
 
-Similar to [`sequence`](#sequence), `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform each value in the list of `AsyncResult`.
+Similar to [`sequence`](#sequence), `traverse` will also change the type from a list of `AsyncResult` to an `AsyncResult` with a list. The difference is that `traverse` allows you to use a transformation function to transform each value in the list of `AsyncResult`. `traverse` will make an early return if it reaches an `Error`.
 
 By sending in `id` as the transform function you have implemented `sequence`. Let's have a look how we can solve the example in the `sequence` description using `traverse` instead.
 

--- a/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/Insurello.AsyncExtra.Tests/AsyncExtraTests.fs
@@ -94,6 +94,24 @@ let traverseTests =
               let! actual = AsyncResult.traverse transformer input
               Expect.equal actual expected "should equal"
           }
+          testAsync "should make an early return if there is an Error" {
+              let mutable counter = 0
+
+              let transformer x =
+                  counter <- counter + x
+                  x
+
+              let expected = 1
+
+              let input =
+                  [ (AsyncResult.singleton 1)
+                    (AsyncResult.fromResult (Error "Skip next"))
+                    (AsyncResult.singleton 3) ]
+
+              let! _ = AsyncResult.traverse transformer input
+
+              Expect.equal counter expected "should equal"
+          }
           testAsync "should execute async task in sequence" {
               let mutable orderRun = []
 

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -77,12 +77,14 @@ module AsyncResult =
 
     let traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err> =
         fun transformer list ->
-            let rec fold acc =
-                function
-                | [] -> acc |> List.rev |> singleton
-                | xA :: xAs -> bind (fun x -> fold (transformer x :: acc) xAs) xA
+            let cons tail head = head :: tail
 
-            fold [] list
+            let rec fold remaining acc =
+                match remaining with
+                | [] -> acc |> List.rev |> singleton
+                | xA :: xAs -> xA |> bind (transformer >> cons acc >> fold xAs)
+
+            fold list []
 
     let sequence : List<AsyncResult<'a, 'error>> -> AsyncResult<'a list, 'error> = fun list -> traverse id list
 

--- a/src/Insurello.AsyncExtra/AsyncExtra.fs
+++ b/src/Insurello.AsyncExtra/AsyncExtra.fs
@@ -80,16 +80,16 @@ module AsyncResult =
 
     let traverse : ('a -> 'b) -> List<AsyncResult<'a, 'err>> -> AsyncResult<'b list, 'err> =
         fun transformer list ->
-            let append head tail = tail @ [ head ]
+            let cons head tail = head :: tail
 
             let rec fold acc =
                 function
                 | [] -> acc
                 | xA :: xAs ->
-                    (transformer >> append) <!> xA <*> acc
+                    (transformer >> cons) <!> xA <*> acc
                     |> bind (fun nextAcc -> fold (singleton nextAcc) xAs)
 
-            fold (singleton []) list
+            fold (singleton []) list |> map List.rev
 
     let sequence : List<AsyncResult<'a, 'error>> -> AsyncResult<'a list, 'error> = fun list -> traverse id list
 


### PR DESCRIPTION
`traverse` and `sequence` will make an early return when/if there is an `Error`.

The implementation has been tested on `40 000 000` elements and is tail-call optimized. However, this test has not been added to the test suite due to the time it takes to execute. The new implementation has been compared to the old one and has a similar execution time when everything is `Ok` but a lot quicker if the list contains an `Error`, as expected.